### PR TITLE
MOBILE-238: Implement authentication client

### DIFF
--- a/src/main/kotlin/eu/kevin/api/Endpoint.kt
+++ b/src/main/kotlin/eu/kevin/api/Endpoint.kt
@@ -7,5 +7,8 @@ internal object Endpoint {
     object Path {
         fun initiatePayment() = "/pis/payment"
         fun initiatePaymentRefund(paymentId: String) = "/pis/payment/$paymentId/refunds"
+        fun startAuthentication() = "/auth"
+        fun receiveToken() = "/auth/token"
+        fun receiveTokenContent() = "/auth/token/content"
     }
 }

--- a/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/request/AuthGrantType.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/request/AuthGrantType.kt
@@ -1,0 +1,10 @@
+package eu.kevin.api.models.auth.receiveToken.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class AuthGrantType {
+    @SerialName("authorizationCode") AUTHORIZATION_CODE,
+    @SerialName("refreshToken") REFRESH_TOKEN
+}

--- a/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/request/ReceiveTokenRequest.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/request/ReceiveTokenRequest.kt
@@ -1,0 +1,12 @@
+package eu.kevin.api.models.auth.receiveToken.request
+
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReceiveTokenRequest(
+    val code: String
+) {
+    @Required
+    private val grantType = AuthGrantType.AUTHORIZATION_CODE
+}

--- a/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/request/RefreshTokenRequest.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/request/RefreshTokenRequest.kt
@@ -1,0 +1,12 @@
+package eu.kevin.api.models.auth.receiveToken.request
+
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenRequest(
+    val refreshToken: String
+) {
+    @Required
+    private val grantType = AuthGrantType.REFRESH_TOKEN
+}

--- a/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/response/ReceiveTokenResponse.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/receiveToken/response/ReceiveTokenResponse.kt
@@ -1,0 +1,12 @@
+package eu.kevin.api.models.auth.receiveToken.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReceiveTokenResponse(
+    val tokenType: String,
+    val accessToken: String,
+    val accessTokenExpiresIn: Long,
+    val refreshToken: String,
+    val refreshTokenExpiresIn: Long
+)

--- a/src/main/kotlin/eu/kevin/api/models/auth/receiveTokenContent/ReceiveTokenContentRequest.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/receiveTokenContent/ReceiveTokenContentRequest.kt
@@ -1,0 +1,5 @@
+package eu.kevin.api.models.auth.receiveTokenContent
+
+data class ReceiveTokenContentRequest(
+    val accessToken: String
+)

--- a/src/main/kotlin/eu/kevin/api/models/auth/receiveTokenContent/ReceiveTokenContentResponse.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/receiveTokenContent/ReceiveTokenContentResponse.kt
@@ -1,0 +1,11 @@
+package eu.kevin.api.models.auth.receiveTokenContent
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReceiveTokenContentResponse(
+    val clientConsent: Boolean,
+    val expiresIn: Long,
+    val bankName: String,
+    val bankId: String
+)

--- a/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/AuthenticationScopes.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/AuthenticationScopes.kt
@@ -1,0 +1,13 @@
+package eu.kevin.api.models.auth.startAuthentication.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class AuthenticationScopes {
+    @SerialName("payments") PAYMENTS,
+    @SerialName("accounts_details") ACCOUNTS_DETAILS,
+    @SerialName("accounts_balances") ACCOUNTS_BALANCES,
+    @SerialName("accounts_transactions") ACCOUNTS_TRANSACTIONS,
+    @SerialName("accounts_basic") ACCOUNTS_BASIC
+}

--- a/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/CardMethod.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/CardMethod.kt
@@ -1,0 +1,6 @@
+package eu.kevin.api.models.auth.startAuthentication.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class CardMethod

--- a/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/StartAuthenticationRequest.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/StartAuthenticationRequest.kt
@@ -1,0 +1,11 @@
+package eu.kevin.api.models.auth.startAuthentication.request
+
+data class StartAuthenticationRequest @JvmOverloads constructor(
+    val requestId: String,
+    val redirectUrl: String,
+    var bankId: String? = null,
+    var redirectPreferred: Boolean? = null,
+    var scopes: List<AuthenticationScopes>? = null,
+    var email: String? = null,
+    var cardMethod: CardMethod? = null
+)

--- a/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/StartAuthenticationRequestBody.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/request/StartAuthenticationRequestBody.kt
@@ -1,0 +1,9 @@
+package eu.kevin.api.models.auth.startAuthentication.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StartAuthenticationRequestBody(
+    val email: String? = null,
+    val cardMethod: CardMethod? = null
+)

--- a/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/response/StartAuthenticationResponse.kt
+++ b/src/main/kotlin/eu/kevin/api/models/auth/startAuthentication/response/StartAuthenticationResponse.kt
@@ -1,0 +1,9 @@
+package eu.kevin.api.models.auth.startAuthentication.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StartAuthenticationResponse(
+    val authorizationLink: String,
+    val state: String
+)

--- a/src/main/kotlin/eu/kevin/api/services/Client.kt
+++ b/src/main/kotlin/eu/kevin/api/services/Client.kt
@@ -3,6 +3,7 @@ package eu.kevin.api.services
 import eu.kevin.api.Dependencies
 import eu.kevin.api.Endpoint
 import eu.kevin.api.models.Authorization
+import eu.kevin.api.services.auth.AuthClient
 import eu.kevin.api.services.payment.PaymentClient
 import io.ktor.client.*
 import io.ktor.client.features.*
@@ -14,11 +15,8 @@ class Client internal constructor(
     private val apiUrl: String,
     private val httpClient: HttpClient
 ) {
-    val paymentClient by lazy {
-        PaymentClient(
-            httpClient = httpClient.withAuthorization()
-        )
-    }
+    val paymentClient by lazy { PaymentClient(httpClient = httpClient.withAuthorization()) }
+    val authClient by lazy { AuthClient(httpClient = httpClient.withAuthorization()) }
 
     constructor(authorization: Authorization, apiUrl: String) : this(
         authorization = authorization,

--- a/src/main/kotlin/eu/kevin/api/services/auth/AuthClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/auth/AuthClient.kt
@@ -1,0 +1,61 @@
+package eu.kevin.api.services.auth
+
+import eu.kevin.api.Endpoint
+import eu.kevin.api.models.auth.receiveToken.request.ReceiveTokenRequest
+import eu.kevin.api.models.auth.receiveToken.request.RefreshTokenRequest
+import eu.kevin.api.models.auth.receiveToken.response.ReceiveTokenResponse
+import eu.kevin.api.models.auth.receiveTokenContent.ReceiveTokenContentRequest
+import eu.kevin.api.models.auth.receiveTokenContent.ReceiveTokenContentResponse
+import eu.kevin.api.models.auth.startAuthentication.request.StartAuthenticationRequest
+import eu.kevin.api.models.auth.startAuthentication.request.StartAuthenticationRequestBody
+import eu.kevin.api.models.auth.startAuthentication.response.StartAuthenticationResponse
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+class AuthClient internal constructor(
+    private val httpClient: HttpClient
+) {
+    suspend fun startAuthentication(request: StartAuthenticationRequest): StartAuthenticationResponse =
+        httpClient.post(
+            path = Endpoint.Path.startAuthentication(),
+            body = StartAuthenticationRequestBody(
+                email = request.email,
+                cardMethod = request.cardMethod
+            )
+        ) {
+            request.run {
+                parameter("bankId", bankId)
+                parameter("redirectPreferred", redirectPreferred)
+                scopes?.forEach {
+                    parameter("scopes", it)
+                }
+
+                headers {
+                    append("Request-Id", requestId)
+                    append("Redirect-URL", redirectUrl)
+                }
+            }
+        }
+
+    suspend fun receiveToken(request: ReceiveTokenRequest): ReceiveTokenResponse =
+        httpClient.post(
+            path = Endpoint.Path.receiveToken(),
+            body = request
+        )
+
+    suspend fun refreshToken(request: RefreshTokenRequest): ReceiveTokenResponse =
+        httpClient.post(
+            path = Endpoint.Path.receiveToken(),
+            body = request
+        )
+
+    suspend fun receiveTokenContent(request: ReceiveTokenContentRequest): ReceiveTokenContentResponse =
+        httpClient.get(
+            path = Endpoint.Path.receiveTokenContent()
+        ) {
+            headers {
+                append(HttpHeaders.Authorization, "Bearer ${request.accessToken}")
+            }
+        }
+}


### PR DESCRIPTION
@edgar-zigis Should we also add [General service](https://docs.kevin.eu/public/platform/v0.3#tag/General-service) API endpoints to the auth client? Kevin-php currently does it this way, but it might be cleaner to separate it to a new client, since general service endpoints are not directly related to auth