### PR TITLE
Handle serialization issues on account transactions

### DIFF
--- a/src/main/kotlin/eu/kevin/api/models/account/transaction/response/AccountTransactionResponse.kt
+++ b/src/main/kotlin/eu/kevin/api/models/account/transaction/response/AccountTransactionResponse.kt
@@ -15,10 +15,10 @@ data class AccountTransactionResponse(
     val isBooked: Boolean,
     val amount: BigDecimal,
     val currencyCode: String,
-    val counterPartyName: String,
+    val counterPartyName: String? = null,
     val counterPartyAccount: CounterPartyAccount,
-    val informationStructured: InformationStructured,
-    val informationUnstructured: String,
-    val bookingDate: LocalDate,
+    val informationStructured: InformationStructured? = null,
+    val informationUnstructured: String? = null,
+    val bookingDate: LocalDate? = null,
     val valueDate: LocalDate? = null
 )

--- a/src/main/kotlin/eu/kevin/api/models/account/transaction/response/CounterPartyAccount.kt
+++ b/src/main/kotlin/eu/kevin/api/models/account/transaction/response/CounterPartyAccount.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CounterPartyAccount(
-    val iban: String,
+    val iban: String? = null,
     val bban: String? = null,
     val pan: String? = null,
     val sortCodeAccountNumber: String? = null

--- a/src/main/kotlin/eu/kevin/api/serializers/LocalDateSerializer.kt
+++ b/src/main/kotlin/eu/kevin/api/serializers/LocalDateSerializer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializer(forClass = LocalDate::class)
@@ -18,6 +19,11 @@ object LocalDateSerializer : KSerializer<LocalDate> {
     }
 
     override fun deserialize(decoder: Decoder): LocalDate {
-        return LocalDate.parse(decoder.decodeString().substringBefore('T'), format)
+        val date = decoder.decodeString()
+        return try {
+            LocalDate.parse(date, DateTimeFormatter.ISO_DATE_TIME)
+        } catch (exception: DateTimeParseException) {
+            LocalDate.parse(date, format)
+        }
     }
 }

--- a/src/main/kotlin/eu/kevin/api/serializers/LocalDateSerializer.kt
+++ b/src/main/kotlin/eu/kevin/api/serializers/LocalDateSerializer.kt
@@ -18,6 +18,6 @@ object LocalDateSerializer : KSerializer<LocalDate> {
     }
 
     override fun deserialize(decoder: Decoder): LocalDate {
-        return LocalDate.parse(decoder.decodeString(), format)
+        return LocalDate.parse(decoder.decodeString().substringBefore('T'), format)
     }
 }

--- a/src/main/kotlin/eu/kevin/api/services/account/AccountClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/account/AccountClient.kt
@@ -11,7 +11,6 @@ import eu.kevin.api.models.account.detail.GetAccountDetailsRequest
 import eu.kevin.api.models.account.list.AccountResponse
 import eu.kevin.api.models.account.transaction.request.GetAccountTransactionsRequest
 import eu.kevin.api.models.account.transaction.response.AccountTransactionResponse
-import eu.kevin.api.serializers.LocalDateSerializer
 import io.ktor.client.*
 import io.ktor.client.request.*
 import kotlinx.serialization.json.Json
@@ -55,8 +54,8 @@ class AccountClient internal constructor(
             path = Endpoint.Paths.Account.getAccountTransactions(accountId = request.accountId)
         ) {
             appendAccountRequestHeaders(headers = request.headers)
-            parameter("dateFrom", serializer.encodeToString(LocalDateSerializer, request.dateFrom))
-            parameter("dateTo", serializer.encodeToString(LocalDateSerializer, request.dateTo))
+            parameter("dateFrom", request.dateFrom)
+            parameter("dateTo", request.dateTo)
         }.data
 
     /**


### PR DESCRIPTION
Using the current PHP demo implementation when a transaction request is executed we get the following response. 
```
{
    "data": [
        {
            "id": "623cd825-b1e0-ab9d-8176-d6cedee962c5",
            "amount": -49,
            "currencyCode": "AED",
            "informationStructured": {
                "type": null,
                "reference": null
            },
            "informationUnstructured": null,
            "counterPartyName": null,
            "counterPartyAccount": [],
            "isBooked": true,
            "valueDate": "2022-03-24T20:44:21.060566Z",
            "bookingDate": "2022-03-25T17:50:22.367770Z",
            "categories": []
        }
    ]
}
```

Based on that response I've updated some fields in the model to be nullable. 
Currently, the dates returned contain only the date without the time. This also relates with this issue on OB - https://gokevin.atlassian.net/browse/OB-6247