### PR TITLE
MOBILE-967: Add missing response fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # kevin. JVM Client
 
-JVM client implementing [kevin. platform API v0.3](https://docs.kevin.eu/public/platform/v0.3).
+JVM client implementing [kevin. platform API v0.3](https://api-reference.kevin.eu/public/platform/v0.3).
 
 ## Prerequisites
 

--- a/src/main/kotlin/eu/kevin/api/models/general/bank/BankResponse.kt
+++ b/src/main/kotlin/eu/kevin/api/models/general/bank/BankResponse.kt
@@ -12,5 +12,8 @@ data class BankResponse(
     val isSandbox: Boolean,
     val imageUri: String? = null,
     val bic: String,
-    val isBeta: Boolean
+    val isBeta: Boolean,
+    val hasSavingsBanks: Boolean,
+    val isSavingsBank: Boolean,
+    val isAccountLinkingSupported: Boolean
 )


### PR DESCRIPTION
`BankResponse` modal was missing some properties. `isAccountLinkingSupported` field will be supported from tomorrow.