### PR TITLE
Fix code to not append the Bearer if already exist

### DIFF
--- a/src/main/kotlin/eu/kevin/api/extensions/StringExtension.kt
+++ b/src/main/kotlin/eu/kevin/api/extensions/StringExtension.kt
@@ -3,4 +3,4 @@ package eu.kevin.api.extensions
 internal fun String.appendAtStartIfNotExist(
     stringToAppend: String
 ): String =
-    if (this.startsWith(stringToAppend)) this else "$stringToAppend $this"
+    if (this.startsWith(stringToAppend)) this else stringToAppend + this

--- a/src/main/kotlin/eu/kevin/api/extensions/StringExtension.kt
+++ b/src/main/kotlin/eu/kevin/api/extensions/StringExtension.kt
@@ -1,0 +1,6 @@
+package eu.kevin.api.extensions
+
+internal fun String.appendAtStartIfNotExist(
+    stringToAppend: String
+): String =
+    if (this.startsWith(stringToAppend)) this else "$stringToAppend $this"

--- a/src/main/kotlin/eu/kevin/api/services/account/AccountClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/account/AccountClient.kt
@@ -73,7 +73,7 @@ class AccountClient internal constructor(
     private fun HttpRequestBuilder.appendAccountRequestHeaders(headers: AccountRequestHeaders) {
         headers.run {
             headers {
-                append("Authorization", accessToken.appendAtStartIfNotExist("Bearer"))
+                append("Authorization", accessToken.appendAtStartIfNotExist("Bearer "))
                 append("PSU-IP-Address", psuIPAddress)
                 append("PSU-User-Agent", psuUserAgent)
                 append("PSU-IP-Port", psuIPPort)

--- a/src/main/kotlin/eu/kevin/api/services/account/AccountClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/account/AccountClient.kt
@@ -2,6 +2,7 @@ package eu.kevin.api.services.account
 
 import eu.kevin.api.Endpoint
 import eu.kevin.api.exceptions.KevinApiErrorException
+import eu.kevin.api.extensions.appendAtStartIfNotExist
 import eu.kevin.api.models.ResponseArray
 import eu.kevin.api.models.account.AccountRequestHeaders
 import eu.kevin.api.models.account.balance.request.GetAccountBalanceRequest
@@ -72,7 +73,7 @@ class AccountClient internal constructor(
     private fun HttpRequestBuilder.appendAccountRequestHeaders(headers: AccountRequestHeaders) {
         headers.run {
             headers {
-                append("Authorization", "Bearer $accessToken")
+                append("Authorization", accessToken.appendAtStartIfNotExist("Bearer"))
                 append("PSU-IP-Address", psuIPAddress)
                 append("PSU-User-Agent", psuUserAgent)
                 append("PSU-IP-Port", psuIPPort)

--- a/src/main/kotlin/eu/kevin/api/services/auth/AuthClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/auth/AuthClient.kt
@@ -2,6 +2,7 @@ package eu.kevin.api.services.auth
 
 import eu.kevin.api.Endpoint
 import eu.kevin.api.exceptions.KevinApiErrorException
+import eu.kevin.api.extensions.appendAtStartIfNotExist
 import eu.kevin.api.extensions.appendQueryParameter
 import eu.kevin.api.models.auth.authentication.request.StartAuthenticationRequest
 import eu.kevin.api.models.auth.authentication.request.StartAuthenticationRequestBody
@@ -83,7 +84,7 @@ class AuthClient internal constructor(
             path = Endpoint.Paths.Auth.receiveTokenContent()
         ) {
             headers {
-                append(HttpHeaders.Authorization, "Bearer ${request.accessToken}")
+                append(HttpHeaders.Authorization, request.accessToken.appendAtStartIfNotExist("Bearer"))
             }
         }
 }

--- a/src/main/kotlin/eu/kevin/api/services/auth/AuthClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/auth/AuthClient.kt
@@ -84,7 +84,7 @@ class AuthClient internal constructor(
             path = Endpoint.Paths.Auth.receiveTokenContent()
         ) {
             headers {
-                append(HttpHeaders.Authorization, request.accessToken.appendAtStartIfNotExist("Bearer"))
+                append(HttpHeaders.Authorization, request.accessToken.appendAtStartIfNotExist("Bearer "))
             }
         }
 }

--- a/src/main/kotlin/eu/kevin/api/services/payment/PaymentClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/payment/PaymentClient.kt
@@ -2,6 +2,7 @@ package eu.kevin.api.services.payment
 
 import eu.kevin.api.Endpoint
 import eu.kevin.api.exceptions.KevinApiErrorException
+import eu.kevin.api.extensions.appendAtStartIfNotExist
 import eu.kevin.api.extensions.appendQueryParameter
 import eu.kevin.api.models.payment.payment.request.InitiatePaymentRequest
 import eu.kevin.api.models.payment.payment.request.InitiatePaymentRequestBody
@@ -43,7 +44,9 @@ class PaymentClient internal constructor(
                 parameter("paymentMethodPreferred", paymentMethodPreferred?.title)
 
                 headers {
-                    accessToken?.let { append(HttpHeaders.Authorization, "Bearer $it") }
+                    accessToken?.let {
+                        append(HttpHeaders.Authorization, it.appendAtStartIfNotExist("Bearer"))
+                    }
                     append("Redirect-URL", redirectUrl)
                     webhookUrl?.let { append("Webhook-URL", it) }
                 }

--- a/src/main/kotlin/eu/kevin/api/services/payment/PaymentClient.kt
+++ b/src/main/kotlin/eu/kevin/api/services/payment/PaymentClient.kt
@@ -45,7 +45,7 @@ class PaymentClient internal constructor(
 
                 headers {
                     accessToken?.let {
-                        append(HttpHeaders.Authorization, it.appendAtStartIfNotExist("Bearer"))
+                        append(HttpHeaders.Authorization, it.appendAtStartIfNotExist("Bearer "))
                     }
                     append("Redirect-URL", redirectUrl)
                     webhookUrl?.let { append("Webhook-URL", it) }


### PR DESCRIPTION
When token is sent with Bearer, an error is returned for invalid Token. This happens because the Bearer is always appended at the beginning of the token. 

