### PR TITLE
change transaction id to be nullable

### DIFF
--- a/src/main/kotlin/eu/kevin/api/models/account/transaction/response/AccountTransactionResponse.kt
+++ b/src/main/kotlin/eu/kevin/api/models/account/transaction/response/AccountTransactionResponse.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 
 @Serializable
 data class AccountTransactionResponse(
-    val id: String,
+    val id: String? = null,
     val isBooked: Boolean,
     val amount: BigDecimal,
     val currencyCode: String,


### PR DESCRIPTION
Fix deserialization issue when transaction id is returned as null. 
```
kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 19: Unexpected 'null' value instead of string literal
"JSON input: {\"data\":[{\"id\":null,\"amount\":\"-7.9\",\"currencyCode.....",
```

OB team returns bank's response. In some cases banks return null as id.