### PR TITLE
Let datetime be specified in get transactions query params

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "eu.kevin"
-version = "0.2.3"
+version = "0.2.5"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/eu/kevin/api/models/account/transaction/request/GetAccountTransactionsRequest.kt
+++ b/src/main/kotlin/eu/kevin/api/models/account/transaction/request/GetAccountTransactionsRequest.kt
@@ -1,11 +1,11 @@
 package eu.kevin.api.models.account.transaction.request
 
 import eu.kevin.api.models.account.AccountRequestHeaders
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class GetAccountTransactionsRequest(
     val accountId: String,
-    val dateFrom: LocalDate,
-    val dateTo: LocalDate,
+    val dateFrom: LocalDateTime,
+    val dateTo: LocalDateTime,
     val headers: AccountRequestHeaders
 )

--- a/src/main/kotlin/eu/kevin/api/serializers/LocalDateTimeSerializer.kt
+++ b/src/main/kotlin/eu/kevin/api/serializers/LocalDateTimeSerializer.kt
@@ -5,19 +5,26 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializer(forClass = LocalDateTime::class)
 object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
-    private val format = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    private val dateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
     override fun serialize(encoder: Encoder, value: LocalDateTime) {
-        encoder.encodeString(value.format(format))
+        encoder.encodeString(value.format(dateTimeFormat))
     }
 
     override fun deserialize(decoder: Decoder): LocalDateTime {
-        return LocalDateTime.parse(decoder.decodeString(), format)
+        return try {
+            LocalDateTime.parse(decoder.decodeString(), dateTimeFormat)
+        } catch (exception: DateTimeParseException) {
+            LocalDate.parse(decoder.decodeString(), dateFormat).atStartOfDay()
+        }
     }
 }

--- a/src/main/kotlin/eu/kevin/api/services/Client.kt
+++ b/src/main/kotlin/eu/kevin/api/services/Client.kt
@@ -42,7 +42,7 @@ class Client internal constructor(
         defaultRequest {
             url.takeFrom(
                 URLBuilder().takeFrom(
-                    URI.create("${apiUrl}/").resolve(".${Endpoint.VERSION}")
+                    URI.create("$apiUrl/").resolve(".${Endpoint.VERSION}")
                 ).apply {
                     encodedPath += url.encodedPath
                 }


### PR DESCRIPTION
Used by banking service to specify datetime (instead of just dates) when fetching bank transactions from platform api

Moved version to 0.2.5 because tag release 0.2.4 is already present even if gradle version is at 0.2.3