### PR TITLE
Report also Kevin-jvm http errors not directly related to Platform api

### DIFF
--- a/src/main/kotlin/eu/kevin/api/Dependencies.kt
+++ b/src/main/kotlin/eu/kevin/api/Dependencies.kt
@@ -33,14 +33,13 @@ object Dependencies {
                     when (exception) {
                         is ResponseException -> {
                             val status = exception.response.status
-                            if (status == HttpStatusCode.BadRequest) {
-                                throw KevinApiErrorException(
-                                    responseStatusCode = status.value,
-                                    responseBody = serializer.decodeFromString(exception.response.readText())
-                                )
-                            } else {
-                                throw exception
-                            }
+                            throw KevinApiErrorException(
+                                responseStatusCode = status.value,
+                                responseBody = if (status == HttpStatusCode.BadRequest)
+                                    serializer.decodeFromString(exception.response.readText())
+                                else null,
+                                externalMessage = exception.message
+                            )
                         }
                     }
                 }

--- a/src/main/kotlin/eu/kevin/api/Dependencies.kt
+++ b/src/main/kotlin/eu/kevin/api/Dependencies.kt
@@ -33,12 +33,14 @@ object Dependencies {
                     when (exception) {
                         is ResponseException -> {
                             val status = exception.response.status
-                            throw KevinApiErrorException(
-                                responseStatusCode = status.value,
-                                responseBody = if (status == HttpStatusCode.BadRequest)
-                                    serializer.decodeFromString(exception.response.readText())
-                                else null
-                            )
+                            if (status == HttpStatusCode.BadRequest) {
+                                throw KevinApiErrorException(
+                                    responseStatusCode = status.value,
+                                    responseBody = serializer.decodeFromString(exception.response.readText())
+                                )
+                            } else {
+                                throw exception
+                            }
                         }
                     }
                 }

--- a/src/main/kotlin/eu/kevin/api/exceptions/KevinApiErrorException.kt
+++ b/src/main/kotlin/eu/kevin/api/exceptions/KevinApiErrorException.kt
@@ -5,7 +5,8 @@ import kotlinx.serialization.json.JsonElement
 
 class KevinApiErrorException internal constructor(
     val responseStatusCode: Int,
-    val responseBody: ClientError?
+    val responseBody: ClientError?,
+    val externalMessage: String?
 ) : Exception() {
 
     @Serializable


### PR DESCRIPTION
Other http errors, apart from the platform specific ones, are returned by the api (404, service down, dns/vpn/firewall problems)
Applications using kevin-jvm benefit from knowing what kind of error happened, instead of the error being hidden by the library